### PR TITLE
Fix tradable spelling

### DIFF
--- a/strategies/momentum_strategy.py
+++ b/strategies/momentum_strategy.py
@@ -39,14 +39,14 @@ class MomentumStrategy(BaseStrategy):
         self.take_profit_pct = self.strategy_config.get('risk_management', {}).get('take_profit_pct', 0.06)
         
         # Universe of symbols to trade
-        self.symbols = self.get_tradeable_symbols()
+        self.symbols = self.get_tradable_symbols()
         
         # Technical indicators cache
         self.indicators_cache = {}
         
         logger.info(f"Momentum Strategy initialized with {len(self.symbols)} symbols")
     
-    def get_tradeable_symbols(self) -> List[str]:
+    def get_tradable_symbols(self) -> List[str]:
         """Get list of symbols to trade"""
         # Default momentum trading universe
         symbols = [

--- a/strategies/pairs_trading.py
+++ b/strategies/pairs_trading.py
@@ -41,10 +41,10 @@ class PairsTradingStrategy(BaseStrategy):
         self.active_pairs = {}
         self.pair_statistics = {}
         
-        logger.info(f"Pairs Trading Strategy initialized with {len(self.get_tradeable_pairs())} pairs")
+        logger.info(f"Pairs Trading Strategy initialized with {len(self.get_tradable_pairs())} pairs")
     
-    def get_tradeable_pairs(self) -> List[Tuple[str, str]]:
-        """Get list of tradeable pairs from configuration"""
+    def get_tradable_pairs(self) -> List[Tuple[str, str]]:
+        """Get list of tradable pairs from configuration"""
         pairs = []
         
         # Get predefined pairs from config
@@ -162,7 +162,7 @@ class PairsTradingStrategy(BaseStrategy):
             logger.warning(f"Error calculating half-life: {e}")
             return np.inf
     
-    def is_pair_tradeable(self, statistics: Dict[str, Any]) -> bool:
+    def is_pair_tradable(self, statistics: Dict[str, Any]) -> bool:
         """Check if pair meets trading criteria"""
         if statistics is None:
             return False
@@ -214,8 +214,8 @@ class PairsTradingStrategy(BaseStrategy):
             return []
     
     def update_pair_statistics(self):
-        """Update statistics for all tradeable pairs"""
-        pairs = self.get_tradeable_pairs()
+        """Update statistics for all tradable pairs"""
+        pairs = self.get_tradable_pairs()
         
         for symbol1, symbol2 in pairs:
             pair_key = f"{symbol1}_{symbol2}"
@@ -230,7 +230,7 @@ class PairsTradingStrategy(BaseStrategy):
         signals = []
         
         for pair_key, stats in self.pair_statistics.items():
-            if not self.is_pair_tradeable(stats):
+            if not self.is_pair_tradable(stats):
                 continue
             
             # Skip if pair is already active


### PR DESCRIPTION
## Summary
- rename tradeable functions and docs to tradable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684b311534e4832398f6073fef8bda6b