### PR TITLE
Fix docstring for max drawdown

### DIFF
--- a/utils/risk_manager.py
+++ b/utils/risk_manager.py
@@ -176,7 +176,7 @@ class RiskManager:
         return risk_checks
     
     def calculate_max_drawdown(self) -> float:
-        """Calculate maximum drawdown from portfolio history"""
+        """Calculate maximum drawdown from daily_pnl_history (recorded portfolio values)"""
         if len(self.daily_pnl_history) < 2:
             return 0.0
         


### PR DESCRIPTION
## Summary
- clarify that `calculate_max_drawdown` uses `daily_pnl_history`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684b3130c3fc83239d5da6243595b12e